### PR TITLE
Remove  from single model option dependencies

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -1165,7 +1165,6 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     c("processModels", modelIdx, "modelNumber"),
     c("processModels", modelIdx, "modelNumberIndependent"),
     c("processModels", modelIdx, "modelNumberMediators"),
-    c("processModels", modelIdx, "modelNumberCovariates"),
     c("processModels", modelIdx, "modelNumberModeratorW"),
     c("processModels", modelIdx, "modelNumberModeratorZ"),
     c("processModels", modelIdx, "independentCovariances"),


### PR DESCRIPTION
Removes an obsolete option from the dependencies of single model states which causes an error in the JASP build. Curiously, the error does not occur in the development version.