### PR TITLE
Align column labels in variable input GUI

### DIFF
--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -95,6 +95,7 @@ Form
                         visible: 	variables.checked
 
                         property int colWidth: (models.width - 3 * 40 * preferencesModel.uiScale) / 4
+						property int labelWidth: modelsGroup.colWidth + jaspTheme.contentMargin
 
                         RowLayout
                         {
@@ -103,22 +104,23 @@ Form
                             Label
                             {
                                 text: qsTr("From")
-                                Layout.preferredWidth: modelsGroup.colWidth
+                                Layout.preferredWidth: modelsGroup.labelWidth
                             }
                             Label
                             {
+								
                                 text: qsTr("To")
-                                Layout.preferredWidth: modelsGroup.colWidth
+                                Layout.preferredWidth: modelsGroup.labelWidth
                             }
                             Label
                             {
                                 text: qsTr("Process Type")
-                                Layout.preferredWidth: modelsGroup.colWidth
+                                Layout.preferredWidth: modelsGroup.labelWidth
                             }
                             Label
                             {
                                 text: qsTr("Process Variable")
-                                Layout.preferredWidth: modelsGroup.colWidth
+                                Layout.preferredWidth: modelsGroup.labelWidth
                             }
                         }
 

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -297,7 +297,7 @@ Form
 					{
                         id: opts
 						title: 		qsTr("Options for %1").arg(rowValue)
-						columns: 	4
+						columns: 	3
                         
 						Group
 						{
@@ -320,7 +320,7 @@ Form
 						Group
 						{
                             title: qsTr("Parameter Estimates")
-							columns: 	1
+							// columns: 	1
 							CheckBox
 							{
 								name: "pathCoefficients"
@@ -344,24 +344,6 @@ Form
 								name: "residualCovariances"
 								label: qsTr("Residual covariances")
 								checked: residualCovariancesForAllModels.checked
-							}
-						}
-
-						Group
-						{
-                            title: qsTr("Path Plots")
-							columns: 	1
-							CheckBox
-							{
-								name: "conceptualPathPlot"
-								label: qsTr("Conceptual")
-								checked: conceptualPathPlotsForAllModels.checked
-							}
-							CheckBox
-							{
-								name: "statisticalPathPlot"
-								label: qsTr("Statistical")
-								checked: statisticalPathPlotsForAllModels.checked
 							}
 						}
 
@@ -413,6 +395,24 @@ Form
 										max: 100000
 									}
 								}
+							}
+						}
+
+						Group
+						{
+                            title: qsTr("Path Plots")
+							columns: 	1
+							CheckBox
+							{
+								name: "conceptualPathPlot"
+								label: qsTr("Conceptual")
+								checked: conceptualPathPlotsForAllModels.checked
+							}
+							CheckBox
+							{
+								name: "statisticalPathPlot"
+								label: qsTr("Statistical")
+								checked: statisticalPathPlotsForAllModels.checked
 							}
 						}
 					}


### PR DESCRIPTION
Fixes a misalignment between the column titles and the column dropdowns in the variable input GUI.