### PR TITLE
Add option to compute R-squared

### DIFF
--- a/inst/help/ClassicProcess.md
+++ b/inst/help/ClassicProcess.md
@@ -80,6 +80,7 @@ This section allows users to specify multiple process models through one of two 
 
 - Parameter labels: Display the labels of parameter in the output tables. For indirect and direct (total) effects, display the equations for the effects.
 - Lavaan syntax: Show the lavaan syntax used to fit the model in the output.
+- R-squared: Show *R*², the proportion of variation explained in each endogenous (outcome) variable from its predictors, in the output.
 - AIC weights: Show the Akaike weights in the summary table in the output.
 - BIC weigths: Show the Schwarz weights in the summary table in the output.
 - Standardized estimates: When `Missing Value Handling` is `Exclude cases listwise`, standardization is applied only based on complete cases.

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -430,8 +430,7 @@ Form
 		{
 			CheckBox { label: qsTr("Parameter labels") 	;		name: "parameterLabels" }
 			CheckBox { label: qsTr("Lavaan syntax")     ;       name: "syntax" }
-			// TODO
-			// CheckBox { label: qsTr("R-squared")         ;       name: "rSquared" }
+			CheckBox { label: qsTr("R-squared")         ;       name: "rSquared" }
 			CheckBox { label: qsTr("AIC weights")         ;     name: "aicWeights" }
 			CheckBox { label: qsTr("BIC weights")         ;     name: "bicWeights" }
 		}

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -50,6 +50,7 @@ Form
             maximumItems:	10
             newItemName:	qsTr("Model 1")
             optionKey:		"name"
+			depends:		["dependent", "covariates", "factors"]
 
             content: Group
             {

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -50,7 +50,6 @@ Form
             maximumItems:	10
             newItemName:	qsTr("Model 1")
             optionKey:		"name"
-			depends:		["dependent", "covariates", "factors"]
 
             content: Group
             {

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1130,7 +1130,7 @@ test_that("R-squared table matches", {
                                      statisticalPathPlot = TRUE, totalEffects = TRUE, localTests = FALSE,
                                      localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options, makeTests = TRUE)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
   
   table <- results[["results"]][["rSquaredTable"]][["data"]]
   jaspTools::expect_equal_tables(table,

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1088,12 +1088,53 @@ test_that("Path plot for multiple dependent variables work", {
                                      localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
   set.seed(1)
   results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
-
+  
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "conceptual-path-plot-multi-dep")
-
+  
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_statPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "statistical-path-plot-multi-dep")
+})
+
+test_that("R-squared table matches", {
+  options <- jaspTools::analysisOptions("ClassicProcess")
+  options$rSquared <- TRUE
+  options$dependent <- "contNormal"
+  options$covariates <- list("contGamma", "debCollin1", "contcor1", "contNormal", "debMiss1")
+  options$factors <- list("facGender")
+  options$statisticalPathPlotsCovariances <- TRUE
+  options$statisticalPathPlotsResidualVariances <- TRUE
+  options$errorCalculationMethod <- "standard"
+  options$ciLevel <- 0.95
+  options$naAction <- "listwise"
+  options$emulation <- "lavaan"
+  options$estimator <- "default"
+  options$moderationProbes <- list(list(probePercentile = 16, value = "16"), list(probePercentile = 50,
+                                                                                  value = "50"), list(probePercentile = 84, value = "84"))
+  options$pathPlotsLegend <- TRUE
+  options$pathPlotsColorPalette <- "colorblind"
+  options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovariances = TRUE,
+                                     inputType = "inputVariables", mediationEffects = TRUE, mediatorCovariances = TRUE,
+                                     modelNumber = 1, modelNumberCovariates = list(), modelNumberIndependent = "",
+                                     modelNumberMediators = list(), modelNumberModeratorW = "",
+                                     modelNumberModeratorZ = "", name = "Model 1", pathCoefficients = TRUE,
+                                     processRelationships = list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "debCollin1"), list(processDependent = "contcor1",
+                                                                                                            processIndependent = "facGender", processType = "mediators",
+                                                                                                            processVariable = "debCollin1"), list(processDependent = "debMiss1",
+                                                                                                                                                  processIndependent = "contGamma", processType = "mediators",
+                                                                                                                                                  processVariable = "debCollin1")), residualCovariances = TRUE,
+                                     statisticalPathPlot = TRUE, totalEffects = TRUE, localTests = FALSE,
+                                     localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options, makeTests = TRUE)
+  
+  table <- results[["results"]][["rSquaredTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list("contNormal", 0.00181189494871836, "debCollin1", 0.0265249455063975,
+                                      "debMiss1", 0.0250288495182258, "contcor1", 0.0112314309960128
+                                 ))
 })


### PR DESCRIPTION
This adds the option to compute R² for all endogeneous variables in each model. This should close #62 

![image](https://github.com/jasp-stats/jaspProcess/assets/41131893/14287b1c-2d5c-413d-86f1-2423cf1977f5)

![image](https://github.com/jasp-stats/jaspProcess/assets/41131893/7d49aeeb-d8dd-4495-9bef-8291cdd00536)

![image](https://github.com/jasp-stats/jaspProcess/assets/41131893/78237d47-6463-4794-bde9-2df09a8d452c)

