### PR TITLE
Add dependency to load values in dropdown controls in right order

### DIFF
--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -50,6 +50,7 @@ Form
             maximumItems:	10
             newItemName:	qsTr("Model 1")
             optionKey:		"name"
+			depends:		["dependent", "covariates", "factors"]
 
             content: Group
             {


### PR DESCRIPTION
The dropdown controls created by. the ComponentsList "processRelationships" depends on the Variables Lists. When loading a JASP file, the dropdown controls must get their values after the Variables lists have got their own values. This dependency is not detected because the Dropdown controls are created dynamically (only when the ComponentsList is created). So we have to set the dependencies explicitly.