### PR TITLE
Fix variable encoding for model number input

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -413,7 +413,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   # Replace encoded Y with user variable
   vars <- gsub(encoding[["Y"]], globalDependent, vars)
 
-  return(vars)
+  return(encodeColNames(vars))
 }
 
 .procModelGraphInputModelNumber <- function(graph, modelOptions, globalDependent) {


### PR DESCRIPTION
Apparently, the variables were not automatically encoded in the model number interface, so here is a fix.