### PR TITLE
Add intercepts to output

### DIFF
--- a/inst/help/ClassicProcess.md
+++ b/inst/help/ClassicProcess.md
@@ -60,7 +60,7 @@ This section allows users to specify multiple process models through one of two 
 		- Moderator Z: Second moderator variable.
 
 - Residual Covariances: Adds covariances between the residuals of variables indicating that they have a common cause not specified in the model. Also adds variances for independent (exogenous) variables. This adds degrees of freedom corresponding to the number of covariances and variances added.
-- Parameter Estimates: Determines which parameter estimates are shown in the output.
+- Parameter Estimates: Determines which parameter estimates are shown in the output. Requesting intercepts adds the mean structure to the model.
 - Path plots: Displays path plots in the output.
 	- Conceptual: Shows a conceptual path plot. These plots contain no parameter labels or estimates and simplify moderation effects in the model structure by omitting direct effects and interactions. Instead moderators point to the path they are moderating. These plots can be shown even when the model is not complete yet (when `Input type` is `Model number`) and are easier to understand than the statistical path plots.
 	- Statistical: Shows a statistical path plot including parameter labels or estimates for all paths.

--- a/inst/help/ClassicProcess.md
+++ b/inst/help/ClassicProcess.md
@@ -80,6 +80,7 @@ This section allows users to specify multiple process models through one of two 
 
 - Parameter labels: Display the labels of parameter in the output tables. For indirect and direct (total) effects, display the equations for the effects.
 - Lavaan syntax: Show the lavaan syntax used to fit the model in the output.
+- R-squared: Show *R*², the proportion of variation explained in each endogenous (outcome) variable from its predictors, in the output.
 - AIC weights: Show the Akaike weights in the summary table in the output.
 - BIC weigths: Show the Schwarz weights in the summary table in the output.
 - Standardized estimates: When `Missing Value Handling` is `Exclude cases listwise`, standardization is applied only based on complete cases.

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -430,8 +430,7 @@ Form
 		{
 			CheckBox { label: qsTr("Parameter labels") 	;		name: "parameterLabels" }
 			CheckBox { label: qsTr("Lavaan syntax")     ;       name: "syntax" }
-			// TODO
-			// CheckBox { label: qsTr("R-squared")         ;       name: "rSquared" }
+			CheckBox { label: qsTr("R-squared")         ;       name: "rSquared" }
 			CheckBox { label: qsTr("AIC weights")         ;     name: "aicWeights" }
 			CheckBox { label: qsTr("BIC weights")         ;     name: "bicWeights" }
 		}

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -50,6 +50,7 @@ Form
             maximumItems:	10
             newItemName:	qsTr("Model 1")
             optionKey:		"name"
+			depends:		["dependent", "covariates", "factors"]
 
             content: Group
             {

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -50,7 +50,6 @@ Form
             maximumItems:	10
             newItemName:	qsTr("Model 1")
             optionKey:		"name"
-			depends:		["dependent", "covariates", "factors"]
 
             content: Group
             {

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -327,6 +327,13 @@ Form
 								name: "pathCoefficients"
 								label: qsTr("Paths")
 								checked: pathCoefficientsForAllModels.checked
+								
+								CheckBox
+  							{
+  								name: "intercepts"
+  								label: qsTr("Intercepts")
+  								checked: interceptsForAllModels.checked
+  							}
 							}
 							CheckBox
 							{
@@ -593,6 +600,13 @@ Form
                     name: 		"pathCoefficientsForAllModels"
                     label: 		qsTr("Paths")
                     checked: 	true
+                    
+                    CheckBox
+                    {
+                        id:			interceptsForAllModels
+                        name: 		"interceptsForAllModels"
+                        label: 		qsTr("Intercepts")
+                    }
                 }
                 CheckBox
                 {

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1130,7 +1130,7 @@ test_that("R-squared table matches", {
                                      statisticalPathPlot = TRUE, totalEffects = TRUE, localTests = FALSE,
                                      localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options, makeTests = TRUE)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
   
   table <- results[["results"]][["rSquaredTable"]][["data"]]
   jaspTools::expect_equal_tables(table,

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1138,3 +1138,71 @@ test_that("R-squared table matches", {
                                       "debMiss1", 0.0250288495182258, "contcor1", 0.0112314309960128
                                  ))
 })
+
+test_that("Path coefficients table with intercepts matches", {
+  options <- jaspTools::analysisOptions("ClassicProcess")
+  options$dependent <- "contNormal"
+  options$covariates <- list("contGamma", "debCollin1", "contcor1", "contNormal", "debMiss1")
+  options$factors <- list("facGender")
+  options$statisticalPathPlotsCovariances <- TRUE
+  options$statisticalPathPlotsResidualVariances <- TRUE
+  options$errorCalculationMethod <- "standard"
+  options$ciLevel <- 0.95
+  options$naAction <- "listwise"
+  options$emulation <- "lavaan"
+  options$estimator <- "default"
+  options$moderationProbes <- list(list(probePercentile = 16, value = "16"), list(probePercentile = 50,
+                                                                                  value = "50"), list(probePercentile = 84, value = "84"))
+  options$pathPlotsLegend <- TRUE
+  options$pathPlotsColorPalette <- "colorblind"
+  options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovariances = TRUE,
+                                     inputType = "inputVariables", mediationEffects = TRUE, mediatorCovariances = TRUE,
+                                     modelNumber = 1, modelNumberCovariates = list(), modelNumberIndependent = "",
+                                     modelNumberMediators = list(), modelNumberModeratorW = "",
+                                     modelNumberModeratorZ = "", name = "Model 1", pathCoefficients = TRUE, intercepts = TRUE,
+                                     processRelationships = list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "debCollin1"), list(processDependent = "contcor1",
+                                                                                                            processIndependent = "facGender", processType = "mediators",
+                                                                                                            processVariable = "debCollin1"), list(processDependent = "debMiss1",
+                                                                                                                                                  processIndependent = "contGamma", processType = "mediators",
+                                                                                                                                                  processVariable = "debCollin1")), residualCovariances = TRUE,
+                                     statisticalPathPlot = TRUE, totalEffects = TRUE, localTests = FALSE,
+                                     localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_pathCoefficientsTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list(-1.81842415998067, 1.75850994333305, -0.0299571083238086, "(Intercept)",
+                                      "<unicode>", 0.973810386382783, "contNormal", 0.91249995702169,
+                                      -0.0328297092983825, 0.653479549943803, 0.712058021425658, 0.68276878568473,
+                                      "(Intercept)", "<unicode>", 0, "debCollin1", 0.0149437622180597,
+                                      45.6892163915453, -4.9479870283803, 83.8830280464201, 39.4675205090199,
+                                      "(Intercept)", "<unicode>", 0.0815750282662664, "debMiss1",
+                                      22.66138964172, 1.74161960643224, -1.53702416025488, 1.76773422033608,
+                                      0.115355030040601, "(Intercept)", "<unicode>", 0.891166767987515,
+                                      "contcor1", 0.843066098831018, 0.136827978494866, 1.7137813220542,
+                                      2.31240655389555, 2.01309393797488, "(Intercept)", "<unicode>",
+                                      0, "contGamma", 0.15271332447005, 13.1821761130587, 0.406563633033025,
+                                      0.603537375908213, 0.505050504470619, "(Intercept)", "<unicode>",
+                                      0, "facGenderm", 0.0502493271378688, 10.0508908922286, -0.165995350051199,
+                                      0.106498401702712, -0.0297484741742436, "contGamma", "<unicode>",
+                                      0.668692399817187, "contNormal", 0.0695149895363656, -0.427943302195006,
+                                      -2.73898714357846, 2.42947526958326, -0.154755936997602, "debCollin1",
+                                      "<unicode>", 0.906565370265694, "contNormal", 1.31850953740219,
+                                      -0.117371875293759, -0.0185979214400448, 0.00248650372610035,
+                                      -0.00805570885697224, "contGamma", "<unicode>", 0.134215466465715,
+                                      "debCollin1", 0.00537877872564405, -1.49768363189316, -0.0391876523573127,
+                                      0.0248902735585444, -0.00714868939938416, "facGenderm", "<unicode>",
+                                      0.661881681066528, "debCollin1", 0.0163467100470457, -0.437316706469394,
+                                      -3.99105068626878, 2.81795395174919, -0.586548367259797, "contGamma",
+                                      "<unicode>", 0.735608480658925, "debMiss1", 1.73702289728957,
+                                      -0.337674516654351, -116.26393123917, 12.0332112282069, -52.1153600054816,
+                                      "debCollin1", "<unicode>", 0.111315707132311, "debMiss1", 32.7294642859176,
+                                      -1.59230715022443, -2.35410384171132, 2.52278252053418, 0.0843393394114301,
+                                      "debCollin1", "<unicode>", 0.945952802832767, "contcor1", 1.24412652495499,
+                                      0.067790001836414, -0.596452849320671, 0.17019409854064, -0.213129375390016,
+                                      "facGenderm", "<unicode>", 0.275824268295476, "contcor1", 0.195576794754527,
+                                      -1.08974776714957))
+})

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1088,12 +1088,53 @@ test_that("Path plot for multiple dependent variables work", {
                                      localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
   set.seed(1)
   results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
-
+  
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "conceptual-path-plot-multi-dep")
-
+  
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_statPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "statistical-path-plot-multi-dep")
+})
+
+test_that("R-squared table matches", {
+  options <- jaspTools::analysisOptions("ClassicProcess")
+  options$rSquared <- TRUE
+  options$dependent <- "contNormal"
+  options$covariates <- list("contGamma", "debCollin1", "contcor1", "contNormal", "debMiss1")
+  options$factors <- list("facGender")
+  options$statisticalPathPlotsCovariances <- TRUE
+  options$statisticalPathPlotsResidualVariances <- TRUE
+  options$errorCalculationMethod <- "standard"
+  options$ciLevel <- 0.95
+  options$naAction <- "listwise"
+  options$emulation <- "lavaan"
+  options$estimator <- "default"
+  options$moderationProbes <- list(list(probePercentile = 16, value = "16"), list(probePercentile = 50,
+                                                                                  value = "50"), list(probePercentile = 84, value = "84"))
+  options$pathPlotsLegend <- TRUE
+  options$pathPlotsColorPalette <- "colorblind"
+  options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovariances = TRUE,
+                                     inputType = "inputVariables", mediationEffects = TRUE, mediatorCovariances = TRUE,
+                                     modelNumber = 1, modelNumberCovariates = list(), modelNumberIndependent = "",
+                                     modelNumberMediators = list(), modelNumberModeratorW = "",
+                                     modelNumberModeratorZ = "", name = "Model 1", pathCoefficients = TRUE,
+                                     processRelationships = list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "debCollin1"), list(processDependent = "contcor1",
+                                                                                                            processIndependent = "facGender", processType = "mediators",
+                                                                                                            processVariable = "debCollin1"), list(processDependent = "debMiss1",
+                                                                                                                                                  processIndependent = "contGamma", processType = "mediators",
+                                                                                                                                                  processVariable = "debCollin1")), residualCovariances = TRUE,
+                                     statisticalPathPlot = TRUE, totalEffects = TRUE, localTests = FALSE,
+                                     localTestType = "cis.loess", localTestBootstrap = FALSE, localTestBootstrapSamples = 1000))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options, makeTests = TRUE)
+  
+  table <- results[["results"]][["rSquaredTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list("contNormal", 0.00181189494871836, "debCollin1", 0.0265249455063975,
+                                      "debMiss1", 0.0250288495182258, "contcor1", 0.0112314309960128
+                                 ))
 })


### PR DESCRIPTION
This adds the option to add intercepts to the output. It also includes a unit test and adjusted help file. This should close #45 

![image](https://github.com/jasp-stats/jaspProcess/assets/41131893/987073b7-95d1-44c8-8341-a4d7e7d56c82)

![image](https://github.com/jasp-stats/jaspProcess/assets/41131893/b5dcb578-ed27-4188-8371-018b2a0b142c)


