### PR TITLE
Fix bootstrapping for empty model number input

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -1191,11 +1191,10 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     return(gettextf("Estimation failed: %s", gsub("lavaan ERROR:", "", jaspBase::.extractErrorMessage(fittedModel))))
   }
 
-  if (options$errorCalculationMethod == "bootstrap") {
-    fittedModel <- .procBootstrap(fittedModel, options$bootstrapSamples)
-  }
-
   if (doFit) {
+    if (options$errorCalculationMethod == "bootstrap") {
+      fittedModel <- .procBootstrap(fittedModel, options$bootstrapSamples)
+    }
     container[["graph"]]$object <- .procGraphAddEstimates(container[["graph"]]$object, fittedModel)
     container[["resCovGraph"]]$object <- .procGraphAddEstimates(container[["resCovGraph"]]$object, fittedModel, type = "variances")
   }


### PR DESCRIPTION
Fixes a bug causing the analysis to crash when selecting bootstrapping and model number input while no variables are specified in the input. See https://github.com/jasp-stats/jasp-desktop/pull/5361

Now, bootstrapping is only done when the model is ready for fitting, i.e., all required variables are specified.