### PR TITLE
Add model name as a dependency for single model output

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -128,7 +128,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
       container$dependOn(
         options = .procGetDependencies(),
         optionContainsValue = list(processModels = modelOptions),
-        nestedOptions = .procGetSingleModelsDependencies(as.character(i))
+        nestedOptions = .procGetSingleModelsDependencies(as.character(i))[-1] # omit model name
       )
       modelsContainer[[modelName]] <- container
     }
@@ -1205,6 +1205,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
 
 .procGetSingleModelsDependencies <- function(modelIdx) {
   return(list(
+    c("processModels", modelIdx, "name"),
     c("processModels", modelIdx, "inputType"),
     c("processModels", modelIdx, "processRelationships"),
     c("processModels", modelIdx, "modelNumber"),

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -127,7 +127,6 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
       container <- createJaspContainer(title = modelName)
       container$dependOn(
         options = .procGetDependencies(),
-        optionContainsValue = list(processModels = modelOptions),
         nestedOptions = .procGetSingleModelsDependencies(as.character(i))[-1] # omit model name
       )
       modelsContainer[[modelName]] <- container


### PR DESCRIPTION
Adds the model name as an explicit dependency for single model output. This prevents results from old renamed models to show up in the output. See https://github.com/jasp-stats/jasp-issues/issues/2469

Also fixes a new bug, where the recomputation of all models was triggered for unrelated dependencies. I am not sure how this got introduced, but removing `optionContainsValue = list(processModels = modelOptions)` fixed it.