### PR TITLE
Fix missing bayes

### DIFF
--- a/R/bayesianProcess.R
+++ b/R/bayesianProcess.R
@@ -280,7 +280,7 @@ BayesianProcess <- function(jaspResults, dataset = NULL, options) {
 
   if (any(isBadWaic)) {
     summaryTable$addFootnote(
-      message = gettext("Warning: WAIC estimate unreliable -- at least one effective parameter estimate (p_waic) larger than 0.4. We recommend using LOO instead."),
+      message = .procBayesBadWaicFootnote(),
       colNames = "waicEst",
       rowNames = names(looResults)[looIsValid][isBadWaic]
     )
@@ -288,7 +288,7 @@ BayesianProcess <- function(jaspResults, dataset = NULL, options) {
 
   if (any(isBadLoo)) {
     summaryTable$addFootnote(
-      message = gettext("Warning: LOO estimate unreliable -- at least one observation with shape parameter (k) of the generalized Pareto distribution higher than 0.5."),
+      message = .procBayesBadLooFootnote(),
       colNames = "looEst",
       rowNames = names(looResults)[looIsValid][isBadLoo]
     )
@@ -296,7 +296,7 @@ BayesianProcess <- function(jaspResults, dataset = NULL, options) {
 
   if (any(!looIsValid)) {
     summaryTable$addFootnote(
-      message = gettext("WAIC and LOO cannot be calculated if no covariances are estimated for independent variables with missing data."),
+      message = .procBayesMissingCovFootnote(),
       colNames = "Model",
       rowNames = names(looResults)[!looIsValid]
     )
@@ -660,6 +660,12 @@ BayesianProcess <- function(jaspResults, dataset = NULL, options) {
 }
 
 # Footnotes ----
+
+.procBayesBadWaicFootnote <- function() gettext("Warning: WAIC estimate unreliable -- at least one effective parameter estimate (p_waic) larger than 0.4. We recommend using LOO instead.")
+
+.procBayesBadLooFootnote <- function() gettext("Warning: LOO estimate unreliable -- at least one observation with shape parameter (k) of the generalized Pareto distribution higher than 0.5.")
+
+.procBayesMissingCovFootnote <- function() gettext("WAIC and LOO cannot be calculated if no covariances are estimated for independent variables with missing data.")
 
 .procBayesDivergentTransitionsFootnote <- function(n) gettextf("Estimates might be biased -- %i divergent transitions after warmup.", n)
 

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -2719,7 +2719,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
 
 .procDagMsg <- function() gettext("Model must be a directed acyclic graph -- it must not contain loops.")
 
-.procHayesModelMsg <- function(modelName, modelNumber) gettextf("%1$s: Hayes model %2$s not implemented", modelName, modelNumber)
+.procHayesModelMsg <- function(modelName, modelNumber) gettextf("%1$s: Hayes configuration %2$s not implemented", modelName, modelNumber)
 
 .procEstimationMsg <- function(graph) gettextf("Estimation failed: %s", jaspBase::.extractErrorMessage(graph))
 

--- a/tests/testthat/test-bayesian-process-general.R
+++ b/tests/testthat/test-bayesian-process-general.R
@@ -1,0 +1,82 @@
+
+test_that("Missing values work without independent covariances", {
+  options <- getOptionsBayesian()
+  options$covariates <- list("contGamma", "debMiss1", "debMiss30", "debMiss80")
+  options$processModels <- list(getProcessModel(list(list(processDependent = "debMiss80",
+                                                                      processIndependent = "debMiss1", processType = "mediators",
+                                                                      processVariable = "contGamma"), list(processDependent = "debMiss80",
+                                                                                                            processIndependent = "debMiss1", processType = "moderators",
+                                                                                                            processVariable = "debMiss30"))))
+  options$processModels[[1]]$independentCovariances <- FALSE
+  options$processModels[[1]]$intercepts <- TRUE
+  set.seed(1)
+  results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+
+  table <- results[["results"]][["modelSummaryTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(0, "Model 1", 69, 2831.84654144799, 1))
+
+	table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_covariancesTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(3, 247082.682637495, 247082.682639476, "debMiss80", 247082.682638674,
+			 247082.682638882, "<unicode>", 1.47997997995841, "debMiss80",
+			 5.62231943175488e-07, 13, 200, 4170694472577044, 4170694472577044,
+			 "contGamma", 4170694472577044, 4170694472577044, "<unicode>",
+			 1, "contGamma", 0, 200))
+
+	table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_mediationEffectsTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(5, -0.215014442770641, -0.215014442745862, 16, "debMiss1", "debMiss80",
+			 "", -0.215014442756571, -0.21501444275598, "<unicode>", "",
+			 1.23357468767469, 6.35337884146757e-12, 12, 3, -0.18480506979993,
+			 -0.184805069765363, 50, "debMiss1", "debMiss80", "", -0.18480506978615,
+			 -0.184805069787627, "<unicode>", "", 1.22102000729357, 9.2366670408536e-12,
+			 12, 3, -0.156508691446879, -0.156508691356733, 84, "debMiss1",
+			 "debMiss80", "", -0.156508691410163, -0.15650869141524, "<unicode>",
+			 "", 1.21180315926087, 2.37910221006175e-11, 12, 2, 2.83446062008339e-05,
+			 2.8344611918101e-05, "", "debMiss1", "contGamma", "debMiss80",
+			 2.83446089538845e-05, 2.83446088828221e-05, "<unicode>", "<unicode>",
+			 1.47813384110761, 1.25333611660017e-12, 20))
+
+	table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_pathCoefficientsTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(2, 10.7311891062555, 10.7311891062592, "(Intercept)", 10.7311891062573,
+			 10.7311891062573, "<unicode>", "Normal(0,10)", 1.43368621479253,
+			 "debMiss80", 1.24632365453172e-12, 200, 9, 2.02273919008768,
+			 2.02273919008995, "(Intercept)", 2.022739190089, 2.02273919008909,
+			 "<unicode>", "Normal(0,10)", 1.51094915827383, "contGamma",
+			 7.48383462073232e-13, 29, "", "", "", "(Intercept)", 3.04981150169565,
+			 3.04981150169565, "<unicode>", "", "", "debMiss1", 0, "", "",
+			 "", "", "(Intercept)", 7.77994174547826, 7.77994174547826, "<unicode>",
+			 "", "", "debMiss30", 0, "", "", "", "", "(Intercept)", 65.4570525044341,
+			 65.4570525044341, "<unicode>", "", "", "debMiss1:debMiss30",
+			 0, "", 2, -0.202420561677805, -0.202420561675789, "debMiss1",
+			 -0.202420561676554, -0.202420561676334, "<unicode>", "Normal(0,10)",
+			 1.59051728543811, "debMiss80", 5.7497099716731e-13, 17, 22,
+			 -2.05878988110189, -2.05878988110119, "contGamma", -2.05878988110167,
+			 -2.05878988110188, "<unicode>", "Normal(0,10)", 1.0102650617491,
+			 "debMiss80", 3.18546447565261e-13, 200, 4, 0.00698607346950194,
+			 0.00698607347380862, "debMiss30", 0.00698607347216579, 0.0069860734730944,
+			 "<unicode>", "Normal(0,10)", 1.32125795144338, "debMiss80",
+			 1.56328226026569e-12, 26, 3, 0.00199270270091905, 0.00199270270483371,
+			 "debMiss1:debMiss30", 0.00199270270253432, 0.00199270270228076,
+			 "<unicode>", "Normal(0,10)", 1.20912970536564, "debMiss80",
+			 1.02567182787816e-12, 12, 2, -1.37676079420648e-05, -1.37676051650611e-05,
+			 "debMiss1", -1.37676065022804e-05, -1.37676064677624e-05, "<unicode>",
+			 "Normal(0,10)", 1.47813384110761, "contGamma", 6.08773603852703e-13,
+			 20))
+
+	table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_totalEffectsTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(6, -0.214986098162984, -0.214986098136969, 16, "Total", "debMiss1",
+			 "debMiss80", -0.214986098147617, -0.214986098147454, "<unicode>",
+			 1.23523817690533, 6.42520580960565e-12, 12, 3, -0.184776725191038,
+			 -0.184776725157721, 50, "Total", "debMiss1", "debMiss80", -0.184776725177196,
+			 -0.184776725178046, "<unicode>", 1.31831286741936, 9.45306659136354e-12,
+			 12, 3, -0.156480346837987, -0.156480346749083, 84, "Total",
+			 "debMiss1", "debMiss80", -0.156480346801209, -0.156480346805431,
+			 "<unicode>", 1.24436459705305, 2.39371216048077e-11, 12, 2,
+			 2.83446062008339e-05, 2.8344611918101e-05, "", "Total indirect",
+			 "debMiss1", "debMiss80", 2.83446089538845e-05, 2.83446088828221e-05,
+			 "<unicode>", 1.47813384110761, 1.25333611660017e-12, 20))
+})


### PR DESCRIPTION
Fixes #89

When no variances are estimated for independent variables with missing data in the Bayesian analysis, WAIC and LOO cannot be estimated because `rstan::loo` does not allow it. We omit the fit indices for such models and display `NA` in the model summary table instead. When intercepts are requested, those involving independent variables are not estimated by the model but only from the data itself (they don't have posteriors). We include them in the path coefficients table but set their CIs and diagnostics to `NA`.