### PR TITLE
Fix add model

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -151,11 +151,11 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     modelOptions <- options[["processModels"]][[i]]
     modelName <- modelOptions[["name"]]
 
-    if (is.null(modelsContainer[[modelName]][["graph"]])) {
-      graph <- try(.procModelGraphSingleModel(options[["processModels"]][[i]], globalDependent = options[["dependent"]]))
-      state <- createJaspState(object = graph)
-      modelsContainer[[modelName]][["graph"]] <- state
-    }
+    # We need to regenerate the model graph everytime because it gets
+    # modified in a later step
+    graph <- try(.procModelGraphSingleModel(options[["processModels"]][[i]], globalDependent = options[["dependent"]]))
+    state <- createJaspState(object = graph)
+    modelsContainer[[modelName]][["graph"]] <- state
   }
 }
 
@@ -188,7 +188,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     type            <- path[["processType"       ]]
     processVariable <- path[["processVariable"   ]]
 
-    # Encode variable names if the model is defined through the "Variables" dialog
+    # Encode variable names if the model is defined through the "Paths" dialog
     if (inputVariables) {
       dependent       <- encodeColNames(dependent)
       independent     <- encodeColNames(independent)

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -1425,7 +1425,12 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     modelOptions <- options[["processModels"]][[i]]
     modelName <- modelOptions[["name"]]
 
-    if (!is.null(modelsContainer[[modelName]][["fittedModel"]]) && !is.null(modelsContainer[[modelName]][["graph"]]$object)) {
+    if (
+      !is.null(modelsContainer[[modelName]][["fittedModel"]]) &&
+      !is.null(modelsContainer[[modelName]][["graph"]]) &&
+      inherits(modelsContainer[[modelName]][["fittedModel"]]$object, "lavaan") &&
+      .procCheckGraph(modelsContainer[[modelName]][["graph"]]$object)
+    ) {
       fittedModel <- modelsContainer[[modelName]][["fittedModel"]]$object
       modelsContainer[[modelName]][["graph"]]$object <- .procGraphAddEstimatesSingleModel(modelsContainer[[modelName]][["graph"]]$object, fittedModel)
       modelsContainer[[modelName]][["resCovGraph"]]$object <- .procGraphAddEstimatesSingleModel(modelsContainer[[modelName]][["resCovGraph"]]$object, fittedModel, type = "variances")

--- a/inst/qml/common/PathPlotOptions.qml
+++ b/inst/qml/common/PathPlotOptions.qml
@@ -23,11 +23,11 @@ import JASP.Controls
 
 Group
 {
-	title: qsTr("Path Plots")
 	columns: 1
 
 	Group
 	{
+		title: qsTr("Statistical Path Plots")
 		columns: 3
 		CheckBox
 		{

--- a/inst/qml/common/VariablesForm.qml
+++ b/inst/qml/common/VariablesForm.qml
@@ -27,7 +27,7 @@ VariablesForm
 	{
 		name:				"dependent"
 		title:				qsTr("Dependent Variable")
-		suggestedColumns:	["scale"]
+		allowedColumns:		["ordinal", "scale"]
 		singleVariable:		true
 	}
 	AssignedVariablesList


### PR DESCRIPTION
Fixes #99 by recreating the model graphs every time the analysis is run. This is necessary because the graphs are modified later (dummy variables and interaction terms are added). The modifications need to run every time because they also add additional variables to the dataset which is reloaded at every run. This is the simplest solution and recreating the model graphs leads to very little computational overhead. For the future, decoupling the dataset modifications from the model modifications might be a better option, but this would create some overhead too.

Also restricts the dependent variable to be ordinal or scale type (which both are converted to `numeric` in R) because lavaan currently cannot handle categorical outcomes.

Fixes a bug so that estimates are only added to graphs when both models are estimated and the graphs are valid.

