### PR TITLE
Fix variable input types

### DIFF
--- a/inst/qml/common/VariablesForm.qml
+++ b/inst/qml/common/VariablesForm.qml
@@ -27,19 +27,19 @@ VariablesForm
 	{
 		name:				"dependent"
 		title:				qsTr("Dependent Variable")
-		allowedColumns:		["ordinal", "scale"]
+		allowedColumns:		["scale"]
 		singleVariable:		true
 	}
 	AssignedVariablesList
 	{
 		name:			"covariates"
 		title:			qsTr("Continuous Predictors")
-		allowedColumns:	["ordinal", "scale"]
+		allowedColumns:	["scale"]
 	}
 	AssignedVariablesList
 	{
 		name:			"factors"
 		title:			qsTr("Categorical Predictors")
-		allowedColumns:	["ordinal", "nominal"]
+		allowedColumns:	["nominal"]
 	}
 }


### PR DESCRIPTION
Changes the variable types for the dependent variable and continuous predictors to `scale` and for categorical predictors to `nominal` to reflect the coversion when reading the data in R.