### PR TITLE
Fix lavaan version to 0.6-17

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -470,7 +470,7 @@
     },
     "lavaan": {
       "Package": "lavaan",
-      "Version": "0.6-18",
+      "Version": "0.6-17",
       "Source": "Repository"
     },
     "lifecycle": {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2628

There is a conflict between `blavaan` version 0.5-2 and `lavaan` version 0.6-18, so I changed the pinned version to 0.6-17.

@RensDofferhoff is downgrading package versions now possible?