### PR TITLE
Remove readDataSetToEnd

### DIFF
--- a/R/HayesModels.R
+++ b/R/HayesModels.R
@@ -78,31 +78,11 @@
   }
 
   if (number == 4) {
-    processRelationships <- list(
-      list(
-        processDependent = "Y",
-        processIndependent = "X",
-        processType = "mediators",
-        processVariable = "M"
-      )
-    )
+    processRelationships <- .generateProcessRelationships_4(k)
   }
 
   if (number == 5) {
-    processRelationships <- list(
-      list(
-        processDependent = "Y",
-        processIndependent = "X",
-        processType = "mediators",
-        processVariable = "M"
-      ),
-      list(
-        processDependent = "Y",
-        processIndependent = "X",
-        processType = "moderators",
-        processVariable = "W"
-      )
-    )
+    processRelationships <- .generateProcessRelationships_5(k)
   }
 
   if (number == 6) {
@@ -1567,6 +1547,42 @@
 
   return(.procEncodeProcessRelationships(processRelationships))
 } # end of function on hardcoded models
+
+.generateProcessRelationships_4 <- function(k) {
+  k <- max(k, 1)
+  processRelationships <- lapply(1:k, function(i) {
+    list(
+      processDependent = "Y",
+      processIndependent = "X",
+      processType = "mediators",
+      processVariable = paste0("M", i)
+    )
+  })
+  return(processRelationships)
+}
+
+.generateProcessRelationships_5 <- function(k) {
+  k <- max(k, 1)
+  processRelationships <- lapply(1:k, function(i) {
+    list(
+      processDependent = "Y",
+      processIndependent = "X",
+      processType = "mediators",
+      processVariable = paste0("M", i)
+    )
+  })
+
+  processRelationships <- append(processRelationships,
+    list(list(
+      processDependent = "Y",
+      processIndependent = "X",
+      processType = "moderators",
+      processVariable = "W"
+    ))
+  )
+
+  return(processRelationships)
+}
 
 # model 6
 .generateProcessRelationships_6 <- function(k) {

--- a/R/bayesianProcess.R
+++ b/R/bayesianProcess.R
@@ -27,8 +27,6 @@ BayesianProcess <- function(jaspResults, dataset = NULL, options) {
     return()
   }
   options$naAction <- "listwise"
-  # Read dataset
-  dataset <- .procReadData(options)
   # Check for errors in dataset
   .procErrorHandling(dataset, options)
   # Create a container for each model

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -81,7 +81,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     "meanCenteredModeration", "standardizedModelEstimates", "errorCalculationMethod", "bootstrapCiType",
     "mcmcBurnin", "mcmcSamples", "mcmcChains", "seed", "setSeed", "nuPriorMu",
     "nuPriorSigma", "betaPriorMu", "betaPriorSigma", "psiPriorAlpha",
-    "psiPriorBeta", "rhoPriorAlpha", "rhoPriorBeta"
+    "psiPriorBeta", "rhoPriorAlpha", "rhoPriorBeta", "moderationProbes"
   ))
 }
 

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -26,8 +26,6 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     .procModelSummaryTable(jaspResults, options, NULL)
     return()
   }
-  # Read dataset
-  dataset <- .procReadData(options)
   # Check for errors in dataset
   .procErrorHandling(dataset, options)
   # Create a container for each model
@@ -468,7 +466,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   return(graph)
 }
 
-.procReadData <- function(options) {
+.procReadData <- function(dataset, options) {
   # Read in selected variables from dataset
   dataset <- .readDataSetToEnd(
     columns.as.numeric = c(options[['dependent']], options[['covariates']]),

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -466,16 +466,6 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   return(graph)
 }
 
-.procReadData <- function(dataset, options) {
-  # Read in selected variables from dataset
-  dataset <- .readDataSetToEnd(
-    columns.as.numeric = c(options[['dependent']], options[['covariates']]),
-    columns.as.factor = options[['factors']]
-  )
-
-  return(dataset)
-}
-
 .procAddFactorDummyIntVars <- function(jaspResults, dataset, options) {
   modelsContainer <- jaspResults[["modelsContainer"]]
 

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -392,10 +392,10 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   # Get encoding
   encoding <- .procVarEncoding()
 
-  independent <- modelOptions[["modelNumberIndependent"]][["value"]]
-  mediators   <- modelOptions[["modelNumberMediators"  ]][["value"]]
-  modW        <- modelOptions[["modelNumberModeratorW" ]][["value"]]
-  modZ        <- modelOptions[["modelNumberModeratorZ" ]][["value"]]
+  independent <- modelOptions[["modelNumberIndependent"]]
+  mediators   <- modelOptions[["modelNumberMediators"  ]]
+  modW        <- modelOptions[["modelNumberModeratorW" ]]
+  modZ        <- modelOptions[["modelNumberModeratorZ" ]]
 
   # Apply the JASP coding to X, W, Z, and M if the user has specified the variables and 'vars' still contains the dummy version
   if (independent != "" && encoding$X %in% vars) {
@@ -1500,10 +1500,10 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   
   # Create model options dummy object
   modelOptions <- list(
-    modelNumberIndependent = list(value = independent),
-    modelNumberMediators = list(value = mediators),
-    modelNumberModeratorW = list(value = modW),
-    modelNumberModeratorZ = list(value = modZ)
+    modelNumberIndependent = independent,
+    modelNumberMediators = mediators,
+    modelNumberModeratorW = modW,
+    modelNumberModeratorZ = modZ
   )
 
   # Check which hard-coded model matches user model

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -12,6 +12,7 @@ Description
 	maintainer	: "JASP Team <info@jasp-stats.org>"
 	website		: "https://jasp-stats.org"
 	license		: "GPL (>= 2)"
+	preloadData : true
 
 	GroupTitle
 	{

--- a/inst/qml/BayesianProcess.qml
+++ b/inst/qml/BayesianProcess.qml
@@ -55,7 +55,6 @@ Form
                     Common.InputVariables {
 						visible: inputType.value == "inputVariables"
 						adjustedWidth: models.width - 2 * jaspTheme.contentMargin
-						colWidth: (models.width - 3 * 40 * preferencesModel.uiScale) / 4
 					}
 
                     Common.InputModelNumber {

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -26,12 +26,10 @@ Form
 {
 	Common.VariablesForm {}
 
-
 	Section
 	{
 		title: qsTr("Models")
 		columns: 1
-
 
 		TabView
 		{
@@ -44,6 +42,7 @@ Form
 			content: Group
 			{
 				childControlsArea.anchors.leftMargin: jaspTheme.contentMargin
+
 				Common.InputType
 				{
 					id: inputType
@@ -56,7 +55,6 @@ Form
 				{
 					visible: inputType.value == "inputVariables"
 					adjustedWidth: models.width - 2 * jaspTheme.contentMargin
-					colWidth: (models.width - 3 * 40 * preferencesModel.uiScale) / 4
 				}
 
 				Common.InputModelNumber
@@ -230,6 +228,7 @@ Form
 
 		Common.PathPlotOptions {}
 	}
+
 	Section
 	{
 		id: advanced

--- a/inst/qml/common/InputModelNumber.qml
+++ b/inst/qml/common/InputModelNumber.qml
@@ -52,7 +52,7 @@ Group
 		{
 			name: 				"modelNumberMediators"
 			title: 				qsTr("Mediators M")
-			allowedColumns: 	["scale", "ordinal"]
+			allowedColumns: 	["scale", "nominal"]
 		}
 		// TODO
 		// AssignedVariablesList

--- a/inst/qml/common/InputVariables.qml
+++ b/inst/qml/common/InputVariables.qml
@@ -48,8 +48,7 @@ Group
 				id: 				    procIndep
 				name: 				    'processIndependent'
 				source: 			    ['covariates', 'factors']
-				fieldWidth:				modelsGroup.colWidth
-				fixedWidth:				true
+				fieldWidth:			    modelsGroup.colWidth
 				addEmptyValue: 		    true
 				onCurrentValueChanged:
 				{
@@ -68,9 +67,8 @@ Group
 				id: 				procDep
 				name: 				'processDependent'
 				source: 			["dependent", "processVariable"] //, {name: "processRelationships.processVariable", use: "discardIndex=" + (relations.count - 1)}]
-				addEmptyValue: 		true
 				fieldWidth:			modelsGroup.colWidth
-				fixedWidth:			true
+				addEmptyValue: 		true
 				onCurrentValueChanged:
 				{
 					if (currentIndex > 0 && (procVar.currentValue == currentValue || procIndep.currentValue == currentValue))
@@ -95,7 +93,6 @@ Group
 					{ label: qsTr("Direct"), 		value: 'directs'		}
 				]
 				fieldWidth:			modelsGroup.colWidth
-				fixedWidth:			true
 				addEmptyValue: 		true
 				onCurrentValueChanged:
 				{
@@ -112,7 +109,6 @@ Group
 				enabled: 			    procType.currentValue != "directs"
 				source: 			    procType.currentValue == 'mediators' ? ['covariates'] : ['covariates', 'factors']
 				fieldWidth:				modelsGroup.colWidth
-				fixedWidth:				true
 				addEmptyValue: 		    true
 				onCurrentValueChanged:
 				{

--- a/inst/qml/common/InputVariables.qml
+++ b/inst/qml/common/InputVariables.qml
@@ -23,38 +23,10 @@ import JASP.Controls
 
 Group
 {
-	property int adjustedWidth: parent.width
-
 	id: 		modelsGroup
 
-	property int colWidth: parent.width / 4 - jaspTheme.contentMargin
-	property int labelWidth: modelsGroup.colWidth + jaspTheme.contentMargin
-
-	RowLayout
-	{
-		Layout.margins: 	jaspTheme.contentMargin
-		Label
-		{
-			text: qsTr("From")
-			Layout.preferredWidth: modelsGroup.labelWidth
-		}
-		Label
-		{
-			
-			text: qsTr("To")
-			Layout.preferredWidth: modelsGroup.labelWidth
-		}
-		Label
-		{
-			text: qsTr("Process Type")
-			Layout.preferredWidth: modelsGroup.labelWidth
-		}
-		Label
-		{
-			text: qsTr("Process Variable")
-			Layout.preferredWidth: modelsGroup.labelWidth
-		}
-	}
+	property int adjustedWidth: parent.width
+	property int colWidth: (adjustedWidth / 4)  - 4 * jaspTheme.contentMargin
 
 	ComponentsList
 	{
@@ -63,10 +35,12 @@ Group
 		preferredWidth: 		adjustedWidth
 		itemRectangle.color: 	jaspTheme.controlBackgroundColor
 		minimumItems:           1
+		headerLabels:			[qsTr("From "), qsTr("To"), qsTr("Process Type"), qsTr("Process Variable")]
 		rowComponent: 			RowLayout
 		{
 			id: 		rowComp
 			enabled: 	rowIndex === relations.count - 1
+			spacing:	jaspTheme.contentMargin
 
 			Layout.columnSpan: 4
 			DropDown
@@ -74,7 +48,8 @@ Group
 				id: 				    procIndep
 				name: 				    'processIndependent'
 				source: 			    ['covariates', 'factors']
-				controlMinWidth: 	    modelsGroup.colWidth
+				fieldWidth:				modelsGroup.colWidth
+				fixedWidth:				true
 				addEmptyValue: 		    true
 				onCurrentValueChanged:
 				{
@@ -93,8 +68,9 @@ Group
 				id: 				procDep
 				name: 				'processDependent'
 				source: 			["dependent", "processVariable"] //, {name: "processRelationships.processVariable", use: "discardIndex=" + (relations.count - 1)}]
-				controlMinWidth: 	modelsGroup.colWidth
 				addEmptyValue: 		true
+				fieldWidth:			modelsGroup.colWidth
+				fixedWidth:			true
 				onCurrentValueChanged:
 				{
 					if (currentIndex > 0 && (procVar.currentValue == currentValue || procIndep.currentValue == currentValue))
@@ -118,7 +94,8 @@ Group
 					{ label: qsTr("Confounder"), 	value: 'confounders'	},
 					{ label: qsTr("Direct"), 		value: 'directs'		}
 				]
-				controlMinWidth: 	modelsGroup.colWidth
+				fieldWidth:			modelsGroup.colWidth
+				fixedWidth:			true
 				addEmptyValue: 		true
 				onCurrentValueChanged:
 				{
@@ -134,7 +111,8 @@ Group
 				name: 				    'processVariable'
 				enabled: 			    procType.currentValue != "directs"
 				source: 			    procType.currentValue == 'mediators' ? ['covariates'] : ['covariates', 'factors']
-				controlMinWidth: 	    modelsGroup.colWidth
+				fieldWidth:				modelsGroup.colWidth
+				fixedWidth:				true
 				addEmptyValue: 		    true
 				onCurrentValueChanged:
 				{

--- a/tests/testthat/test-bayesian-process-general.R
+++ b/tests/testthat/test-bayesian-process-general.R
@@ -10,7 +10,7 @@ test_that("Missing values work without independent covariances", {
   options$processModels[[1]]$independentCovariances <- FALSE
   options$processModels[[1]]$intercepts <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+  results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
   table <- results[["results"]][["modelSummaryTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -90,7 +90,7 @@ test_that("Incomplete Hayes configuration works", {
   options$processModels[[1]]$modelNumber <- 5
   options$processModels[[1]]$localTests <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+  results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
 	testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]

--- a/tests/testthat/test-bayesian-process-integration.R
+++ b/tests/testthat/test-bayesian-process-integration.R
@@ -42,7 +42,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -168,7 +168,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "facExperim")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -293,7 +293,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -481,7 +481,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -657,7 +657,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -885,7 +885,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -1103,7 +1103,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "mediators", processVariable = "debCollin1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -1215,7 +1215,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "mediators", processVariable = "debCollin1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -1334,7 +1334,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -1602,7 +1602,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -1840,7 +1840,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -2124,7 +2124,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor2")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -2382,7 +2382,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "mediators", processVariable = "contcor1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -2558,7 +2558,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "mediators", processVariable = "contcor1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -2741,7 +2741,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "contcor1")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 
@@ -2987,7 +2987,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
             processType = "moderators", processVariable = "facExperim")),
     residualCovariances = TRUE, statisticalPathPlot = TRUE, totalEffects = TRUE))
 set.seed(1)
-results <- jaspTools::runAnalysis("BayesianProcess", "debug", options)
+results <- jaspTools::runAnalysis("BayesianProcess", "debug.csv", options)
 
 
 

--- a/tests/testthat/test-classic-process-integration-custom-models.R
+++ b/tests/testthat/test-classic-process-integration-custom-models.R
@@ -37,7 +37,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -142,7 +142,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -251,7 +251,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -343,7 +343,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -437,7 +437,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -566,7 +566,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -698,7 +698,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -817,7 +817,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -937,7 +937,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1057,7 +1057,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1179,7 +1179,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1308,7 +1308,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1437,7 +1437,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1584,7 +1584,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1723,7 +1723,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1852,7 +1852,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1985,7 +1985,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -2119,7 +2119,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -8,13 +8,13 @@ test_that("Error handling works - observations", {
           list(processDependent = "contNormal", processIndependent = "contGamma",
               processType = "moderators", processVariable = "debNaN"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   expect_identical(results[["status"]], "validationError", label = "Observations check")
 
   options$covariates <- list("contGamma")
   options$factors <- list("debNaN")
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   expect_identical(results[["status"]], "validationError", label = "Observations check")
 })
 
@@ -27,7 +27,7 @@ test_that("Error handling works - variance", {
           list(processDependent = "contNormal", processIndependent = "contGamma",
               processType = "moderators", processVariable = "debSame"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   expect_identical(results[["status"]], "validationError", label = "Variance check")
 })
 
@@ -40,7 +40,7 @@ test_that("Error handling works - infinity", {
           list(processDependent = "contNormal", processIndependent = "contGamma",
               processType = "moderators", processVariable = "debInf"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   expect_identical(results[["status"]], "validationError", label = "Infinity check")
 })
 
@@ -52,7 +52,7 @@ test_that("Error handling works - covariance", {
           list(processDependent = "contNormal", processIndependent = "debCollin1",
               processType = "moderators", processVariable = "debCollin2"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   expect_identical(results[["status"]], "validationError", label = "Covariance check")
 })
 
@@ -834,7 +834,7 @@ test_that("Bootstrapping works", {
                                                                                                             processIndependent = "contGamma", processType = "moderators",
                                                                                                             processVariable = "contcor1"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   table <- results[["results"]][["modelSummaryTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -919,7 +919,7 @@ test_that("Bootstrapping works (percentile interval)", {
                                                                                                             processVariable = "contcor1"))))
 
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   table <- results[["results"]][["modelSummaryTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -1002,7 +1002,7 @@ test_that("Missing values work", {
                                                                                                             processIndependent = "debMiss1", processType = "moderators",
                                                                                                             processVariable = "debMiss30"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   table <- results[["results"]][["modelSummaryTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -1097,7 +1097,7 @@ test_that("Not implemented Hayes models error message work", {
   options$processModels[[1]]$localTests <- TRUE
   options$processModels[[2]]$localTests <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   refMsg <- jaspProcess:::.procHayesModelMsg("Model 1", modelNumber)
 
@@ -1199,7 +1199,7 @@ test_that("No implied conditional independencies error message works", {
                                                                       processVariable = "debCollin1"))))
   options$processModels[[1]]$localTests <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   refMsg <- jaspProcess:::.procNoImpliedTestsMsg()
 
@@ -1223,7 +1223,7 @@ test_that("Invalid test type error message works", {
                                                                                                             processVariable = "facGender"))))
   options$processModels[[1]]$localTests <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   refMsg <- jaspProcess:::.procLocalTestLinearMsg()
 
@@ -1248,7 +1248,7 @@ test_that("Local tests work for factors with loess test type", {
   options$processModels[[1]]$localTests <- TRUE
   options$processModels[[1]]$localTestType <- "cis.loess"
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
   table <- results[["results"]][["localTestContainer"]][["collection"]][["localTestContainer_Model 1"]][["collection"]][["localTestContainer_Model 1_localTestTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
                                  list(-0.206103108541346, 0.17035274701811, "contGamma", -0.0139864082891252,
@@ -1265,7 +1265,7 @@ test_that("Path plots for empty moderator model works", {
   options$processModels[[1]]$modelNumberIndependent <- list(value = "contGamma")
   options$processModels[[1]]$modelNumberMediators <- list(value = "debCollin1")
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
@@ -1289,7 +1289,7 @@ test_that("Path plot for multiple dependent variables work", {
                                                                                                                                                   processVariable = "debCollin1"))))
 
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
@@ -1314,7 +1314,7 @@ test_that("R-squared table matches", {
                                                                                                                                                   processIndependent = "contGamma", processType = "mediators",
                                                                                                                                                   processVariable = "debCollin1"))))
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   table <- results[["results"]][["rSquaredTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -1338,7 +1338,7 @@ test_that("Path coefficients table with intercepts matches", {
                                                                                                                                                   processVariable = "debCollin1"))))
   options$processModels[[1]]$intercepts <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_pathCoefficientsTable"]][["data"]]
 	jaspTools::expect_equal_tables(table,
@@ -1388,7 +1388,7 @@ test_that("Directed acyclic graph error message works", {
               processType = "mediators", processVariable = "debCollin1")), name = "Model 2"))
   options$processModels[[1]]$localTests <- TRUE
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   refMsg <- jaspProcess:::.procEstimationMsg(jaspProcess:::.procDagMsg())
 
@@ -1412,7 +1412,7 @@ test_that("Incomplete Hayes configuration works", {
   options$processModels[[1]]$localTests <- TRUE
   options$processModels[[1]]$modelNumberIndependent <- list(value = "contGamma")
   set.seed(1)
-  results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
   plotName <- results[["results"]][["pathPlotContainer"]][["collection"]][["pathPlotContainer_Model 1"]][["collection"]][["pathPlotContainer_Model 1_conceptPathPlot"]][["data"]]
 	testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]

--- a/tests/testthat/test-classic-process-integration-hayes-models.R
+++ b/tests/testthat/test-classic-process-integration-hayes-models.R
@@ -37,7 +37,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -157,7 +157,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -276,7 +276,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -458,7 +458,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -629,7 +629,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -847,7 +847,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1056,7 +1056,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1161,7 +1161,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1270,7 +1270,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1406,7 +1406,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1538,7 +1538,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1681,7 +1681,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1820,7 +1820,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -1976,7 +1976,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -2123,7 +2123,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -2348,7 +2348,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -2557,7 +2557,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -2820,7 +2820,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -3050,7 +3050,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -3313,7 +3313,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -3563,7 +3563,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -3869,7 +3869,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -4149,7 +4149,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -4425,7 +4425,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -4678,7 +4678,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -4825,7 +4825,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -4970,7 +4970,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -5138,7 +5138,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -5300,7 +5300,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -5534,7 +5534,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -5752,7 +5752,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -6048,7 +6048,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -6316,7 +6316,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -6590,7 +6590,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -6849,7 +6849,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -7081,7 +7081,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -7292,7 +7292,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -7535,7 +7535,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -7754,7 +7754,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -8009,7 +8009,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -8246,7 +8246,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -8525,7 +8525,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -8771,7 +8771,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -8933,7 +8933,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -9094,7 +9094,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -9267,7 +9267,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -9434,7 +9434,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -9683,7 +9683,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -9916,7 +9916,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -10175,7 +10175,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -10414,7 +10414,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -10676,7 +10676,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -10922,7 +10922,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -11207,7 +11207,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -11461,7 +11461,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -11714,7 +11714,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -11951,7 +11951,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -12215,7 +12215,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -12457,7 +12457,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -12738,7 +12738,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -13004,7 +13004,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -13306,7 +13306,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -13579,7 +13579,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -13870,7 +13870,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -14148,7 +14148,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -14446,7 +14446,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -14734,7 +14734,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -15091,7 +15091,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -15438,7 +15438,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -15714,7 +15714,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -15975,7 +15975,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -16285,7 +16285,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -16565,7 +16565,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -16734,7 +16734,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -16900,7 +16900,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17072,7 +17072,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17236,7 +17236,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17422,7 +17422,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17598,7 +17598,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17797,7 +17797,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -17979,7 +17979,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -18165,7 +18165,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -18335,7 +18335,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -18511,7 +18511,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -18680,7 +18680,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -18881,7 +18881,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -19075,7 +19075,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -19299,7 +19299,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -19509,7 +19509,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -19704,7 +19704,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -19887,7 +19887,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -20057,7 +20057,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -20232,7 +20232,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 
@@ -20469,7 +20469,7 @@ options$processModels <- list(list(conceptualPathPlot = TRUE, independentCovaria
     localTests = FALSE, localTestType = "cis", localTestBootstrap = FALSE,
     localTestBootstrapSamples = 1000))
 set.seed(1)
-results <- jaspTools::runAnalysis("ClassicProcess", "debug", options)
+results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
 
 
 

--- a/tests/testthat/test-classic-process-unit.R
+++ b/tests/testthat/test-classic-process-unit.R
@@ -393,10 +393,10 @@ test_that("Test that .procReplaceDummyVars works", {
                   "JaspProcess_ModeratorW_Encoded", "JaspProcess_ModeratorZ_Encoded")
 
   modelOptions <-  list(
-    modelNumberIndependent = "contGamma",
-    modelNumberMediators = list("contcor1", "contcor2"),
-    modelNumberModeratorW = "debCollin1",
-    modelNumberModeratorZ = "debCollin2"
+    modelNumberIndependent = list(value = "contGamma"),
+    modelNumberMediators = list(value = list("contcor1", "contcor2")),
+    modelNumberModeratorW = list(value = "debCollin1"),
+    modelNumberModeratorZ = list(value = "debCollin2")
   )
 
   globalDependent <- "contNormal"

--- a/tests/testthat/test-classic-process-unit.R
+++ b/tests/testthat/test-classic-process-unit.R
@@ -393,10 +393,10 @@ test_that("Test that .procReplaceDummyVars works", {
                   "JaspProcess_ModeratorW_Encoded", "JaspProcess_ModeratorZ_Encoded")
 
   modelOptions <-  list(
-    modelNumberIndependent = list(value = "contGamma"),
-    modelNumberMediators = list(value = list("contcor1", "contcor2")),
-    modelNumberModeratorW = list(value = "debCollin1"),
-    modelNumberModeratorZ = list(value = "debCollin2")
+    modelNumberIndependent = "contGamma",
+    modelNumberMediators = list("contcor1", "contcor2"),
+    modelNumberModeratorW ="debCollin1",
+    modelNumberModeratorZ = "debCollin2"
   )
 
   globalDependent <- "contNormal"
@@ -423,10 +423,10 @@ test_that("Test that .procModelGraphInputModelNumber works", {
   igraph::E(graph)$target <- edgeList[,2]
 
   modelOptions <-  list(
-    modelNumberIndependent = list(value = "contGamma"),
-    modelNumberMediators = list(value = "contcor1"),
-    modelNumberModeratorW = list(value = "contcor2"),
-    modelNumberModeratorZ = list(value = "")
+    modelNumberIndependent = "contGamma",
+    modelNumberMediators = "contcor1",
+    modelNumberModeratorW = "contcor2",
+    modelNumberModeratorZ = ""
   )
 
   globalDependent <- "contNormal"
@@ -602,10 +602,10 @@ test_that("Test that .procIsModelNumberGraph works", {
   modelNumberTrue <- 5
   modelNumberFalse <- 6
   modelOptions <-  list(
-    modelNumberIndependent = list(value = "contGamma"),
-    modelNumberMediators = list(value = "contcor1"),
-    modelNumberModeratorW = list(value = "contcor2"),
-    modelNumberModeratorZ = list(value = "")
+    modelNumberIndependent = "contGamma",
+    modelNumberMediators = "contcor1",
+    modelNumberModeratorW = "contcor2",
+    modelNumberModeratorZ = ""
   )
   globalDependent <- "contNormal"
 


### PR DESCRIPTION
Removes the deprecated `readDataSetToEnd` function.

Fixes https://github.com/jasp-stats/jasp-test-release/issues/2784
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2783
Fixes https://github.com/jasp-stats/jasp-issues/issues/2942
Closes https://github.com/jasp-stats/jasp-issues/issues/3019