### PR TITLE
Default r2 + legend

### DIFF
--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -154,7 +154,7 @@ Form
 		{
 			CheckBox { label: qsTr("Parameter labels");				name: "parameterLabels" }
 			CheckBox { label: qsTr("Lavaan syntax");       			name: "syntax" 			}
-			CheckBox { label: qsTr("R-squared");       				name: "rSquared" 		}
+			CheckBox { label: qsTr("R-squared");       				name: "rSquared"; checked: true}
 			CheckBox { label: qsTr("AIC weights");     				name: "aicWeights" 		}
 			CheckBox { label: qsTr("BIC weights");     				name: "bicWeights" 		}
 			CheckBox { label: qsTr("Hayes configuration number"); 	name: "hayesNumber";  	}

--- a/inst/qml/common/PathPlotOptions.qml
+++ b/inst/qml/common/PathPlotOptions.qml
@@ -58,6 +58,7 @@ Group
 			{
 				name: "pathPlotsLegendLabels"
 				label: qsTr("Labels")
+				checked: true
 			}
 			CheckBox
 			{


### PR DESCRIPTION
I think it makes sense to have R^2 checked by default, and legend in the path plot - also based on some feedback i got from teachers - do you agree Malte? 