### PR TITLE
Add moderated mediation index

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -2408,23 +2408,23 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     return(paste(row[["lhs"]], op, row[["rhs"]]))
   })
 
-  parNamesAbbr <- abbreviate(unique(unlist(parTable[c("lhs", "rhs")])))
-  
   graph <- dagitty::dagitty(paste("dag {", paste(arrows, collapse = "\n")," } "))
 
   localTestResult <- dagitty::localTests(
-    graph, dataset,
+    graph,
+    dataset,
     type = testType,
     conf.level = options$ciLevel,
-    R = nReps
+    R = nReps,
+    abbreviate.names = FALSE
   )
 
   if (nrow(localTestResult) > 0) {
     implicationSplit <- strsplit(row.names(localTestResult), "\\s+(\\|+|_+\\|+_+)\\s+")
-    localTestTable[["lhs"]]  <- sapply(implicationSplit, function(row) names(parNamesAbbr)[parNamesAbbr == row[1]])
+    localTestTable[["lhs"]]  <- sapply(implicationSplit, function(row) row[1])
     localTestTable[["op1"]]  <- rep("\u2AEB", length(implicationSplit))
-    localTestTable[["rhs"]]  <- sapply(implicationSplit, function(row) names(parNamesAbbr)[parNamesAbbr == row[2]])
-    localTestTable[["cond"]] <- sapply(implicationSplit, function(row) { if (length(row) == 3) names(parNamesAbbr)[parNamesAbbr == row[3]] else "" })
+    localTestTable[["rhs"]]  <- sapply(implicationSplit, function(row) row[2])
+    localTestTable[["cond"]] <- sapply(implicationSplit, function(row) { if (length(row) == 3) row[3] else "" })
     localTestTable[["op2"]]  <- sapply(implicationSplit, function(row) { if (length(row) == 3) "\u2223" else "" })
     localTestTable[[keyEst]] <- localTestResult[[keyEst]]
     localTestTable[[keyErr]] <- p.adjust(localTestResult[[keyErr]], method = adjustMethod)

--- a/inst/help/ClassicProcess.md
+++ b/inst/help/ClassicProcess.md
@@ -87,6 +87,7 @@ This section allows users to specify multiple process models through one of two 
 - AIC weights: Show the Akaike weights in the summary table in the output.
 - BIC weigths: Show the Schwarz weights in the summary table in the output.
 - Hayes configuration number: Display the configuration number according to Hayes (2022).
+- Moderated mediation index: Display the index of moderated mediation (Hayes, 2015) for each moderated indirect path in a separate table for each model. For indirect paths that have dual moderation (i.e., the same moderator moderates multiple relationships) or moderated moderation, the index cannot be calculated and is therefore omitted.
 - Mean-centered moderation: Continuous variables involved in moderation effects are mean-centered before entering the analysis. When `Missing Value Handling` is `Exclude cases listwise`, centering is applied only based on complete cases.
 - Standardized estimates: Adds standardized parameter estimates to the output tables. The standardization is done by multiplying the estimate with (*SD*<sub>X</sub>/*SD*<sub>Y</sub>) where *SD*<sub>X</sub> and *SD*<sub>Y</sub> are the model-implied standard deviations for the independent and dependent variable, respectively. Note that the standardization of estimates of interaction effects is based on the product of the standard deviations of the individual terms and not on the standard deviation of the product term, i.e., (*SD*<sub>X</sub>*SD*<sub>W</sub>/*SD*<sub>Y</sub>) instead of (*SD*<sub>XW</sub>/*SD*<sub>Y</sub>), where *SD*<sub>W</sub> is the model-implied standard deviation of the moderator. The estimates of (conditional) indirect and total effects are also only standardized by (*SD*<sub>X</sub>/*SD*<sub>Y</sub>) but not by standard deviations of mediators or moderators. For effects involving categorical independent variables, estimates are partially standardized, i.e., only multiplied by *SD*<sub>Y</sub>. Conditional effects are probed on the unstandardized scale of moderators. See Cheung and Cheung (2023) for details.
 - Confidence intervals: The level of confidence intervals for parameter estimates in the output tables.
@@ -125,6 +126,8 @@ This section allows users to specify multiple process models through one of two 
 Ankan, A., Wortel, I. M. N., & Textor, J. (2021). Testing graphical causal models using the R package “dagitty.” *Current Protocols, 1*(2), e45. https://doi.org/10.1002/cpz1.45
 
 Cheung, S. F., Cheung, S. H. (2023). manymome: An R package for computing the indirect effects, conditional effects, and conditional indirect effects, standardized or unstandardized, and their bootstrap confidence intervals, in many (though not all) models. *Behavior Research Methods*. https://doi.org/10.3758/s13428-023-02224-z
+
+Hayes, A. F. (2015). An index and test of linear moderated mediation. *Multivariate Behavioral Research, 50*(1), 1–22. https://doi.org/10.1080/00273171.2014.962683
 
 Hayes, A. F. (2022). *Introduction to mediation, moderation, and conditional process analysis* (3rd Ed.). Guilford Press.
 

--- a/inst/qml/ClassicProcess.qml
+++ b/inst/qml/ClassicProcess.qml
@@ -158,6 +158,7 @@ Form
 			CheckBox { label: qsTr("AIC weights");     				name: "aicWeights" 		}
 			CheckBox { label: qsTr("BIC weights");     				name: "bicWeights" 		}
 			CheckBox { label: qsTr("Hayes configuration number"); 	name: "hayesNumber";  	}
+			CheckBox { label: qsTr("Moderated mediation index");    name: "moderatedMediationIndex"}
 		}
 		Group
 		{

--- a/inst/qml/common/InputModelNumber.qml
+++ b/inst/qml/common/InputModelNumber.qml
@@ -52,7 +52,7 @@ Group
 		{
 			name: 				"modelNumberMediators"
 			title: 				qsTr("Mediators M")
-			allowedColumns: 	["scale", "nominal"]
+			allowedColumns: 	["scale"]
 		}
 		// TODO
 		// AssignedVariablesList

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1437,3 +1437,159 @@ test_that("Incomplete Hayes configuration works", {
 	testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
 	jaspTools::expect_equal_plots(testPlot, "statistical-path-plot-incomplete")
 })
+
+test_that("Moderated mediation index works - no mediation", {
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1", "contcor2", "debMiss1")
+  options$standardizedModelEstimates <- TRUE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "moderators",
+                                                                      processVariable = "contcor1"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+  testthat::expect_length(table, 0)
+})
+
+test_that("Moderated mediation index works - one mediator", {
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1", "contcor2", "debMiss1")
+  options$standardizedModelEstimates <- TRUE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "contcor2"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(-0.0372241295385459, 0.0138064641514258, "X", -0.0117088326935601,
+			 -0.0169524894422013, "contGamma", "contcor1", "contNormal",
+			 "<unicode>", "<unicode>", 0.368430615910006, 0.013018247807739,
+			 -0.899416946618538))
+})
+
+test_that("Moderated mediation index works - two mediators", {
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1", "contcor2", "debMiss1")
+  options$standardizedModelEstimates <- TRUE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "contcor2"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "debMiss1"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(-0.0401352078091745, 0.0126762599776686, "X", -0.013729473915753,
+			 -0.0198141121405139, "contGamma", "contcor1", "contNormal",
+			 "<unicode>", "<unicode>", 0.30817003807017, 0.0134725607723951,
+			 -1.01906936236534))
+})
+
+test_that("Moderated mediation index omitted - moderated moderation", {
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1", "contcor2", "debMiss1")
+  options$standardizedModelEstimates <- TRUE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "contcor2"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor2", processType = "moderators",
+                                                                      processVariable = "debMiss1"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+  testthat::expect_length(table, 0)
+})
+
+test_that("Moderated mediation index omitted - double moderation", {
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1", "contcor2", "debMiss1")
+  options$standardizedModelEstimates <- TRUE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "contcor2"), list(processDependent = "contcor1",
+                                                                      processIndependent = "contGamma", processType = "moderators",
+                                                                      processVariable = "contcor2"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+  testthat::expect_length(table, 0)
+})
+
+test_that("Moderated mediation index works - three-level factor moderator", {
+  set.seed(1)
+  df <- get_fac_df()
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1")
+  options$factors <- list("facTwo", "facThree")
+  options$standardizedModelEstimates <- FALSE
+  options$meanCenteredModeration <- FALSE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "facTwo", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "facThree"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", df, options)
+
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(-0.0944533420329607, 0.157337958192132, 0.0314423080795857, "B",
+			 "E", "facTwo", "contcor1", "contNormal", "<unicode>", "<unicode>",
+			 0.624488481492414, 0.064233654855699, 0.489498972932816, -0.1366942908082,
+			 0.101326362911919, -0.0176839639481404, "C", "E", "facTwo",
+			 "contcor1", "contNormal", "<unicode>", "<unicode>", 0.770871853710656,
+			 0.060720670277004, -0.291234663047479))
+})
+
+test_that("Moderated mediation index works - three-level factor independent", {
+  set.seed(1)
+  df <- get_fac_df()
+  options <- getOptionsClassical()
+  options$dependent <- "contNormal"
+  options$covariates <- list("contcor1")
+  options$factors <- list("facTwo", "facThree")
+  options$standardizedModelEstimates <- FALSE
+  options$meanCenteredModeration <- FALSE
+  options$moderatedMediationIndex <- TRUE
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "facThree", processType = "mediators",
+                                                                      processVariable = "contcor1"), list(processDependent = "contNormal",
+                                                                      processIndependent = "contcor1", processType = "moderators",
+                                                                      processVariable = "facTwo"))))
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", df, options)
+
+  table <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_modMedIndTable"]][["data"]]
+	jaspTools::expect_equal_tables(table,
+		list(-0.0839681794968253, 0.141113234310038, 0.0285725274066065, "B",
+			 "E", "facThree", "contcor1", "contNormal", "<unicode>", "<unicode>",
+			 0.618760560766996, 0.0574197831139442, 0.497607720842606, -0.118634291170619,
+			 0.0994066560855568, -0.00961381754253112, "C", "E", "facThree",
+			 "contcor1", "contNormal", "<unicode>", "<unicode>", 0.862779808586041,
+			 0.0556237127253498, -0.172836674711031))
+})


### PR DESCRIPTION
Adds the moderated mediation index displayed in a separate table for the Classical Process Analysis as requested by https://github.com/jasp-stats/jasp-issues/issues/3331. Implements the approach described in:
Hayes, A. F. (2015). An Index and Test of Linear Moderated Mediation. Multivariate Behavioral Research, 50(1), 1–22. https://doi.org/10.1080/00273171.2014.962683.

Does not calculate the index when a moderator moderates the same path twice (dual moderation) or for moderated moderated mediation (because then the index is a linear function of the moderating moderator).

![image](https://github.com/user-attachments/assets/b1d272ad-5f24-451e-9268-8b59ee43d7e0)
