### PR TITLE
Fix release bugs

### DIFF
--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -1490,7 +1490,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
 .procResultsFitModel <- function(container, dataset, options, modelOptions) {
   # Check if graph has error message
   if (!.procCheckGraph(container[["graph"]]$object) && jaspBase::isTryError(container[["graph"]]$object)) {
-    return(.procEstimationMsg(container[["graph"]]$object))
+    return(.procEstimationMsg())
   }
 
   # Should model be fitted?
@@ -1516,7 +1516,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   ))
 
   if (jaspBase::isTryError(fittedModel)) {
-    return(.procLavaanMsg(fittedModel))
+    return(.procEstimationMsg())
   }
 
   if (doFit && is.null(lavaan::vcov(fittedModel))) {
@@ -1824,7 +1824,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   } else if (jaspBase:::isTryError(procResult)) {
     container$setError(jaspBase::.extractErrorMessage(procResult))
   } else if (!inherits(procResult, "lavaan")) {
-    container$setError(.procEstimationMsg(.procModelCheckMsg()))
+    container$setError(.procEstimationMsg())
   }
 }
 
@@ -3038,9 +3038,7 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
 
 .procHayesModelMsg <- function(modelName, modelNumber) gettextf("%1$s: Hayes configuration %2$s not implemented", modelName, modelNumber)
 
-.procEstimationMsg <- function(graph) gettextf("Estimation failed: %s", jaspBase::.extractErrorMessage(graph))
-
-.procLavaanMsg <- function(fittedModel) gettextf("Estimation failed: %s", gsub("lavaan ERROR:", "", jaspBase::.extractErrorMessage(fittedModel)))
+.procEstimationMsg <- function() gettextf("Estimation failed because of an internal error.")
 
 .procFimlMsg <- function() gettext("Full Information Maximum Likelihood estimation only available with 'ML' or 'Auto' estimators. Please choose a different estimator or option for missing value handling.")
 

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -708,7 +708,9 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
     modelOptions <- options[["processModels"]][[i]]
     modelName <- modelOptions[["name"]]
 
-    if (!.procCheckGraph(modelsContainer[[modelName]][["graph"]]$object)) next
+    graph <- modelsContainer[[modelName]][["graph"]]$object
+
+    if (!.procCheckGraph(graph) || !.procCheckFitModel(graph)) next
 
     if (is.null(modelsContainer[[modelName]][["modProbes"]])) {
       modProbes <- .procModProbesSingleModel(modelsContainer[[modelName]], dataset, options)

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -654,6 +654,22 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
       exitAnalysisIfErrors = TRUE
     )
   }
+
+  # Check that dependent variabels are continuous
+  checkPath <- function(path, options) {
+    return(path[["processDependent"]] %in% options[["factors"]] || 
+      (path[["processIndependent"]] %in% options[["factors"]] && path[["processType"]] == "confounders"))
+  }
+
+  for (mod in options[["processModels"]]) {
+    if (mod[["inputType"]] == "inputVariables") {
+      for (path in mod[["processRelationships"]]) {
+        if (checkPath(path, options)) {
+          .quitAnalysis(gettext("Dependent variables must be continuous."))
+        }
+      }
+    }
+  }
 }
 
 .procMeanCenter <- function(graph, dataset, options) {

--- a/inst/qml/common/InputVariables.qml
+++ b/inst/qml/common/InputVariables.qml
@@ -47,7 +47,7 @@ Group
 			{
 				id: 				    procIndep
 				name: 				    'processIndependent'
-				source: 			    ['covariates', 'factors']
+				source: 			    procType.currentValue == 'confounders' ? ['covariates'] : ['covariates', 'factors']
 				fieldWidth:			    modelsGroup.colWidth
 				addEmptyValue: 		    true
 				onCurrentValueChanged:
@@ -66,7 +66,7 @@ Group
 			{
 				id: 				procDep
 				name: 				'processDependent'
-				source: 			["dependent", "processVariable"] //, {name: "processRelationships.processVariable", use: "discardIndex=" + (relations.count - 1)}]
+				source: 			["dependent", { name: "processVariable", discard: "factors" }] // Factors are not allowed as dependent variables
 				fieldWidth:			modelsGroup.colWidth
 				addEmptyValue: 		true
 				onCurrentValueChanged:

--- a/tests/testthat/test-classic-process-integration-general.R
+++ b/tests/testthat/test-classic-process-integration-general.R
@@ -1593,3 +1593,19 @@ test_that("Moderated mediation index works - three-level factor independent", {
 			 "contcor1", "contNormal", "<unicode>", "<unicode>", 0.862779808586041,
 			 0.0556237127253498, -0.172836674711031))
 })
+
+test_that("Estimation failed error message works", {
+  options <- getOptionsClassical()
+  options$processModels <- list(getProcessModel(list(list(processDependent = "contNormal",
+                                                                      processIndependent = "contGamma", processType = "moderators",
+                                                                      processVariable = "facGender"))))
+  options$naAction <- "listwise"
+  options$estimator <- "wls"
+  set.seed(1)
+  results <- jaspTools::runAnalysis("ClassicProcess", "debug.csv", options)
+
+  refMsg <- jaspProcess:::.procEstimationMsg()
+
+  msg <- results[["results"]][["parEstContainer"]][["collection"]][["parEstContainer_Model 1"]][["collection"]][["parEstContainer_Model 1_pathCoefficientsTable"]][["error"]][["errorMessage"]]
+  expect_equal(msg, refMsg)
+})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2958
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2959
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2961

I modified the QML interface to prevent https://github.com/jasp-stats/jasp-test-release/issues/2958, so that uses cannot specify categorical variables as dependent variables. I also added a check in R that displays an error message (in case someone tries doing that from R).

For https://github.com/jasp-stats/jasp-test-release/issues/2961, I changed the error message to something generic (`"Estimation failed because of an internal error"`), as these errors are typically due to bugs/low-level error messages in lavaan.