### PR TITLE
fix: make factor level labels name-safe in Process models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,8 @@
 
 # jaspProcess (development version)
 
-
+## Fixed
+* Process models with a categorical predictor no longer error when a factor level label contains a space or other special character (e.g. "emotion regulation"). Such labels are now coerced to syntactically valid names before being used in mean-centering and lavaan model syntax ([Issue #3597](https://github.com/jasp-stats/jasp-issues/issues/3597)).
 
 ---
 

--- a/R/classicProcess.R
+++ b/R/classicProcess.R
@@ -474,8 +474,37 @@ ClassicProcess <- function(jaspResults, dataset = NULL, options) {
   return(graph)
 }
 
+.procSafeFactorLevels <- function(dataset, options) {
+  # Make factor level labels safe to embed in constructed variable names.
+  # Factor dummy variables are named <factor><level> (via model.matrix and
+  # paste0(factor, levels)), and those names are later parsed as code: as R
+  # expressions in .procMeanCenter (str2lang) and as lavaan model syntax. A
+  # level label containing a space or other character that is invalid inside a
+  # name (e.g. "emotion regulation", "self-help") therefore breaks parsing.
+  # See jasp-stats/jasp-issues#3597.
+  #
+  # Only characters that are invalid *within* a name are replaced; the level is
+  # always prefixed by the (already safe) factor name, so a leading digit is
+  # fine and purely numeric levels ("1", "2", ...) are left untouched. This is a
+  # positional 1:1 relabel, so contrasts, level ordering and all estimates are
+  # unchanged; only labels with special characters change (e.g.
+  # "emotion regulation" -> "emotion.regulation"). make.unique guards against the
+  # rare case of two distinct levels collapsing to the same safe label.
+  for (f in unlist(options[["factors"]])) {
+    if (is.null(dataset[[f]])) next
+    dataset[[f]] <- as.factor(dataset[[f]])
+    safeLevels <- gsub("[^A-Za-z0-9._]+", ".", levels(dataset[[f]]))
+    levels(dataset[[f]]) <- make.unique(safeLevels, sep = "_")
+  }
+  return(dataset)
+}
+
 .procAddFactorDummyIntVars <- function(jaspResults, dataset, options) {
   modelsContainer <- jaspResults[["modelsContainer"]]
+
+  # Make factor level labels safe before they are glued into dummy variable
+  # names and parsed as R/lavaan code (jasp-stats/jasp-issues#3597)
+  dataset <- .procSafeFactorLevels(dataset, options)
 
   for (i in 1:length(options[["processModels"]])) {
     modelOptions <- options[["processModels"]][[i]]

--- a/tests/testthat/test-classic-process-unit.R
+++ b/tests/testthat/test-classic-process-unit.R
@@ -797,3 +797,41 @@ test_that("Test that .procEffectsTablesGetConditionalLabels converts SD labels f
   result <- jaspProcess:::.procEffectsTablesGetConditionalLabels(paths, mods)
   expect_equal(result[["W"]], c("Mean-1SD", "Mean", "Mean+1.5SD"))
 })
+
+# Safe factor levels ------------------------------------------------------
+# Factor dummy variables are named <factor><level> and later parsed as R/lavaan
+# code, so level labels with spaces or other special characters used to crash
+# the analysis. See jasp-stats/jasp-issues#3597.
+
+test_that("Test that .procSafeFactorLevels makes special characters in factor levels name-safe", {
+  dataset <- data.frame(
+    X = c("control", "emotion regulation", "self-help", "v2.0 test"),
+    stringsAsFactors = FALSE
+  )
+  result <- jaspProcess:::.procSafeFactorLevels(dataset, list(factors = list("X")))
+  expect_equal(levels(result[["X"]]), c("control", "emotion.regulation", "self.help", "v2.0.test"))
+})
+
+test_that("Test that .procSafeFactorLevels leaves valid and numeric levels unchanged", {
+  dataset <- data.frame(
+    fac = c("control", "experimental", "m", "f"),
+    num = c("1", "2", "3", "10"),
+    stringsAsFactors = FALSE
+  )
+  result <- jaspProcess:::.procSafeFactorLevels(dataset, list(factors = list("fac", "num")))
+  expect_equal(levels(result[["fac"]]), c("control", "experimental", "f", "m"))
+  expect_equal(levels(result[["num"]]), c("1", "10", "2", "3"))
+})
+
+test_that("Test that .procSafeFactorLevels keeps colliding levels distinct", {
+  dataset <- data.frame(X = c("a b", "a-b"), stringsAsFactors = FALSE)
+  result <- jaspProcess:::.procSafeFactorLevels(dataset, list(factors = list("X")))
+  expect_equal(levels(result[["X"]]), c("a.b", "a.b_1"))
+})
+
+test_that("Test that .procSafeFactorLevels only relabels declared factor columns", {
+  dataset <- data.frame(X = c("a b", "c d"), Z = c("e f", "g h"), stringsAsFactors = FALSE)
+  result <- jaspProcess:::.procSafeFactorLevels(dataset, list(factors = list("X")))
+  expect_equal(levels(result[["X"]]), c("a.b", "c.d"))
+  expect_identical(result[["Z"]], c("e f", "g h"))
+})


### PR DESCRIPTION
Factor dummy variables are named <factor><level> and those names are later parsed as code: as R expressions in mean-centering (str2lang) and as lavaan model syntax. A level label containing a space or other character that is invalid inside a name (e.g. "emotion regulation", "self-help") therefore crashed the analysis. .procSafeFactorLevels() now coerces level labels to valid names before they are used; the level is always prefixed by the factor name, so leading digits and purely numeric levels are left unchanged.

Fix https://github.com/jasp-stats/jasp-issues/issues/3597
